### PR TITLE
feat: wait on the channels and tasks when shutdown is called

### DIFF
--- a/rust/examples/basic.rs
+++ b/rust/examples/basic.rs
@@ -2,7 +2,6 @@ use dylibso_observe_sdk::{
     adapter::{stdout::StdoutAdapter, Collector},
     add_to_linker,
 };
-use tokio::task;
 
 #[tokio::main]
 pub async fn main() -> anyhow::Result<()> {
@@ -45,8 +44,8 @@ pub async fn main() -> anyhow::Result<()> {
         .get_func(&mut store, function_name)
         .expect("function exists");
     f.call(&mut store, &[], &mut []).unwrap();
-    task::yield_now().await;
-    collector.shutdown().await;
+
+    collector.shutdown().await?;
 
     Ok(())
 }

--- a/rust/examples/datadog.rs
+++ b/rust/examples/datadog.rs
@@ -1,5 +1,7 @@
-use dylibso_observe_sdk::adapter::{datadog::{DatadogAdapter, DatadogConfig}, new_trace_id};
-use tokio::task;
+use dylibso_observe_sdk::adapter::{
+    datadog::{DatadogAdapter, DatadogConfig},
+    new_trace_id,
+};
 
 /// You need the datadog agent running on localhost for this example to work
 #[tokio::main]
@@ -44,7 +46,6 @@ pub async fn main() -> anyhow::Result<()> {
     trace_ctx.set_trace_id(new_trace_id()).await;
     f.call(&mut store, &[], &mut []).unwrap();
 
-    task::yield_now().await;
     trace_ctx.shutdown().await;
 
     Ok(())

--- a/rust/examples/otel-stdout.rs
+++ b/rust/examples/otel-stdout.rs
@@ -1,6 +1,5 @@
-use dylibso_observe_sdk::adapter::otelstdout::OtelStdoutAdapter;
 use dylibso_observe_sdk::adapter::new_trace_id;
-use tokio::task;
+use dylibso_observe_sdk::adapter::otelstdout::OtelStdoutAdapter;
 
 #[tokio::main]
 pub async fn main() -> anyhow::Result<()> {
@@ -43,9 +42,7 @@ pub async fn main() -> anyhow::Result<()> {
     trace_ctx.set_trace_id(new_trace_id()).await;
     f.call(&mut store, &[], &mut []).unwrap();
 
-    task::yield_now().await;
-    trace_ctx.shutdown().await;
+    trace_ctx.shutdown().await?;
 
     Ok(())
 }
-

--- a/rust/examples/zipkin.rs
+++ b/rust/examples/zipkin.rs
@@ -1,5 +1,4 @@
-use dylibso_observe_sdk::adapter::{zipkin::{ZipkinAdapter}, new_trace_id};
-use tokio::task;
+use dylibso_observe_sdk::adapter::{new_trace_id, zipkin::ZipkinAdapter};
 
 #[tokio::main]
 pub async fn main() -> anyhow::Result<()> {
@@ -42,9 +41,7 @@ pub async fn main() -> anyhow::Result<()> {
     trace_ctx.set_trace_id(new_trace_id()).await;
     f.call(&mut store, &[], &mut []).unwrap();
 
-    task::yield_now().await;
-    trace_ctx.shutdown().await;
+    trace_ctx.shutdown().await?;
 
     Ok(())
 }
-

--- a/rust/src/adapter/datadog.rs
+++ b/rust/src/adapter/datadog.rs
@@ -1,6 +1,6 @@
 use crate::{adapter::datadog_formatter::DatadogFormatter, add_to_linker, Event, Metadata};
 use anyhow::Result;
-use log::warn;
+use log::{error, warn};
 use serde_json::json;
 use std::{
     collections::HashMap,
@@ -41,8 +41,10 @@ impl DatadogTraceCtx {
         self.0.set_metadata("trace_id".to_string(), id).await;
     }
 
-    pub async fn shutdown(&self) {
-        self.0.shutdown().await;
+    pub async fn shutdown(self) {
+        if let Err(e) = self.0.shutdown().await {
+            error!("error shutting down datadog collector : {}", e);
+        };
     }
 }
 

--- a/rust/src/adapter/otelstdout.rs
+++ b/rust/src/adapter/otelstdout.rs
@@ -1,5 +1,4 @@
 use std::sync::Arc;
-use std::{thread, time};
 
 use crate::adapter::otel_formatter::{OtelFormatter, ResourceSpan, Span};
 use crate::adapter::{Adapter, Collector};
@@ -20,8 +19,8 @@ impl OtelTraceCtx {
         self.0.set_metadata("trace_id".to_string(), id).await;
     }
 
-    pub async fn shutdown(&self) {
-        self.0.shutdown().await;
+    pub async fn shutdown(self) -> Result<()> {
+        self.0.shutdown().await
     }
 }
 
@@ -101,7 +100,6 @@ impl OtelStdoutAdapter {
 impl Adapter for OtelStdoutAdapter {
     // flush any remaning spans
     fn shutdown(&self) -> Result<()> {
-        thread::sleep(time::Duration::from_millis(5));
         Ok(())
     }
 

--- a/rust/src/adapter/stdout.rs
+++ b/rust/src/adapter/stdout.rs
@@ -1,9 +1,8 @@
+use anyhow::Result;
 use std::collections::HashMap;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
-use std::thread;
-use std::time::{self, SystemTime};
-use anyhow::Result;
+use std::time::SystemTime;
 
 use crate::adapter::Adapter;
 use crate::Event;
@@ -67,8 +66,6 @@ impl Adapter for StdoutAdapter {
 
     // flush any remaning spans
     fn shutdown(&self) -> Result<()> {
-        // close event stream and join the thread handle
-        thread::sleep(time::Duration::from_millis(5));
         Ok(())
     }
 }


### PR DESCRIPTION
Send a shutdown event and wait for it to propagate through the channel, shutdown the channel, and await the tasks to complete.

closes https://github.com/dylibso/observe-sdk/pull/28