### PR TITLE
feat: add version checking to rust sdk

### DIFF
--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -279,9 +279,7 @@ pub fn add_to_linker<T: 'static>(
     let wasm_instr_info = WasmInstrInfo::new(data)?;
 
     // For now tolerate version info not being present
-    if wasm_instr_info.maj_version.is_some() || wasm_instr_info.min_version.is_some() {
-        let maj_num = wasm_instr_info.maj_version.unwrap();
-        let min_num = wasm_instr_info.min_version.unwrap();
+    if let WasmInstrInfo {maj_version: Some(maj_num), min_version: Some(min_num), ..} = &wasm_instr_info {
         if maj_num != WASM_INSTR_VERSION_MAJOR {
             anyhow::bail!("wasm wasm-instr major version {maj_num} is not equal to {WASM_INSTR_VERSION_MAJOR}!")
         }

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -178,6 +178,95 @@ const MODULE_NAME: &str = "dylibso_observe";
 type EventChannel = (Sender<Event>, Receiver<Event>);
 type FunctionNames = HashMap<u32, String>;
 
+// Static info from instrumentation
+struct WasmInstrInfo {
+    function_names: FunctionNames,
+    maj_version: Option<u32>,
+    min_version: Option<u32>,
+}
+
+impl WasmInstrInfo {
+    fn new(data: &[u8]) -> Result<Self> {
+        let mut function_names = FunctionNames::new();
+        let mut maj_index: Option<u32> = None;
+        let mut min_index: Option<u32> = None;
+        let mut globals = HashMap::<u32, u32>::new();
+        let parser = wasmparser::Parser::new(0);
+        for payload in parser.parse_all(data) {
+            match payload? {
+                wasmparser::Payload::CustomSection(custom) => {
+                    if custom.name() == "name" {
+                        let name_reader =
+                            wasmparser::NameSectionReader::new(custom.data(), custom.data_offset());
+                        for x in name_reader.into_iter() {
+                            if let wasmparser::Name::Function(f) = x? {
+                                for k in f.into_iter() {
+                                    let k = k?;
+                                    function_names.insert(k.index, k.name.to_string());
+                                }
+                            }
+                        }
+                        continue;
+                    }
+                }
+                wasmparser::Payload::GlobalSection(globalsec) => {
+                    for (i, aglob) in globalsec.into_iter().enumerate() {
+                        let glob = aglob.unwrap();
+                        if glob.ty.content_type != wasmparser::ValType::I32 {
+                            continue;
+                        }
+                        let mut reader = glob.init_expr.get_binary_reader();
+                        let opcode = match reader.read_u8() {
+                            Ok(opcode) => opcode,
+                            Err(_) => continue,
+                        };
+                        // i32.const
+                        if opcode != 0x41 {
+                            continue;
+                        }
+                        // due to binaryen limitations u32 version values are encoded as a signed LEB128
+                        // integers so they must be casted back to unsigned
+                        let iv = reader.read_var_i32().unwrap();
+                        let uv = iv as u32;
+                        globals.insert(i as u32, uv);
+                    }
+                }
+                wasmparser::Payload::ExportSection(exportsec) => {
+                    for export in exportsec.into_iter() {
+                        let export = export?;
+                        if export.kind != wasmparser::ExternalKind::Global {
+                            continue;
+                        }
+                        match export.name {
+                            "wasm_instr_version_major" => {
+                                maj_index = Some(export.index);
+                            }
+                            "wasm_instr_version_minor" => {
+                                min_index = Some(export.index);
+                            }
+                            _ => {}
+                        }
+                    }
+                }
+                _ => (),
+            }
+        }
+        let maj_version = match maj_index {
+            Some(maj_index) => Some(*globals.get(&maj_index).unwrap()),
+            None => None,
+        };
+        let min_version = match min_index {
+            Some(min_index) => Some(*globals.get(&min_index).unwrap()),
+            None => None,
+        };
+        return Ok(Self {
+            function_names,
+            maj_version,
+            min_version,
+        });
+    }
+}
+
 /// Link observability import functions required by instrumented wasm code
 pub fn add_to_linker<T: 'static>(
     id: usize,
@@ -186,83 +275,18 @@ pub fn add_to_linker<T: 'static>(
 ) -> Result<EventChannel> {
     let (ctx, events_tx, events_rx) = InstrumentationContext::new(id);
 
-    // Parse the wasm to build up a table of function id to name mapping and check version compat
-    let mut function_names = FunctionNames::new();
-    let mut maj_index: Option<u32> = None;
-    let mut min_index: Option<u32> = None;
-    let mut globals = HashMap::<u32, u32>::new();
-    let parser = wasmparser::Parser::new(0);
-    for payload in parser.parse_all(data) {
-        match payload? {
-            wasmparser::Payload::CustomSection(custom) => {
-                if custom.name() == "name" {
-                    let name_reader =
-                        wasmparser::NameSectionReader::new(custom.data(), custom.data_offset());
-                    for x in name_reader.into_iter() {
-                        if let wasmparser::Name::Function(f) = x? {
-                            for k in f.into_iter() {
-                                let k = k?;
-                                function_names.insert(k.index, k.name.to_string());
-                            }
-                        }
-                    }
-                    continue;
-                }
-            }
-            wasmparser::Payload::GlobalSection(globalsec) => {
-                for (i, aglob) in globalsec.into_iter().enumerate() {
-                    let glob = aglob.unwrap();
-                    if glob.ty.content_type != wasmparser::ValType::I32 {
-                        continue;
-                    }
-                    let mut reader = glob.init_expr.get_binary_reader();
-                    let opcode = match reader.read_u8() {
-                        Ok(opcode) => opcode,
-                        Err(_) => continue,
-                    };
-                    // i32.const
-                    if opcode != 0x41 {
-                        continue;
-                    }
-                    // due to binaryen limitations u32 version values are encoded as a signed LEB128
-                    // integers so they must be casted back to unsigned
-                    let iv = reader.read_var_i32().unwrap();
-                    let uv = iv as u32;
-                    globals.insert(i as u32, uv);
-                }
-            }
-            wasmparser::Payload::ExportSection(exportsec) => {
-                for export in exportsec.into_iter() {
-                    let export = export?;
-                    if export.kind != wasmparser::ExternalKind::Global {
-                        continue;
-                    }
-                    match export.name {
-                        "wasm_instr_version_major" => {
-                            maj_index = Some(export.index);
-                        }
-                        "wasm_instr_version_minor" => {
-                            min_index = Some(export.index);
-                        }
-                        _ => {}
-                    }
-                }
-            }
-            _ => (),
-        }
-    }
+    // load the static wasm-instr info
+    let wasm_instr_info = WasmInstrInfo::new(data)?;
+
     // For now tolerate version info not being present
-    let version_info_present = maj_index.is_some() || min_index.is_some();
-    if version_info_present {
-        let maj_index = maj_index.unwrap();
-        let min_index = min_index.unwrap();
-        let maj_num: u32 = *globals.get(&maj_index).unwrap();
-        let min_num: u32 = *globals.get(&min_index).unwrap();
+    if wasm_instr_info.maj_version.is_some() || wasm_instr_info.min_version.is_some() {
+        let maj_num = wasm_instr_info.maj_version.unwrap();
+        let min_num = wasm_instr_info.min_version.unwrap();
         if maj_num != WASM_INSTR_VERSION_MAJOR {
-            panic!("wasm wasm-instr major version {maj_num} is not equal to {WASM_INSTR_VERSION_MAJOR}!")
+            anyhow::bail!("wasm wasm-instr major version {maj_num} is not equal to {WASM_INSTR_VERSION_MAJOR}!")
         }
         if maj_num < WASM_INSTR_VERSION_MINOR {
-            panic!(
+            anyhow::bail!(
                 "wasm wasm-instr minor version {min_num} is less than {WASM_INSTR_VERSION_MINOR}!"
             )
         }
@@ -276,7 +300,12 @@ pub fn add_to_linker<T: 'static>(
         "instrument_enter",
         t.clone(),
         move |_caller: Caller<T>, params, results| {
-            instrument_enter(params, results, enter_ctx.clone(), &function_names)
+            instrument_enter(
+                params,
+                results,
+                enter_ctx.clone(),
+                &wasm_instr_info.function_names,
+            )
         },
     )?;
 

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -279,7 +279,14 @@ pub fn add_to_linker<T: 'static>(
     let wasm_instr_info = WasmInstrInfo::new(data)?;
 
     // For now tolerate version info not being present
-    if let WasmInstrInfo {maj_version: Some(maj_num), min_version: Some(min_num), ..} = &wasm_instr_info {
+    if let WasmInstrInfo {
+        maj_version: Some(maj_num),
+        min_version: Some(min_num),
+        ..
+    } = &wasm_instr_info
+    {
+        let maj_num = *maj_num;
+        let min_num = *min_num;
         if maj_num != WASM_INSTR_VERSION_MAJOR {
             anyhow::bail!("wasm wasm-instr major version {maj_num} is not equal to {WASM_INSTR_VERSION_MAJOR}!")
         }

--- a/rust/src/version.rs
+++ b/rust/src/version.rs
@@ -1,0 +1,5 @@
+// these control the versions of instrumented wasm supported
+// WASM_INSTR_VERSION_MAJOR must match the instrumented wasm
+// wasmInstrVersionMinor must be <= the value in instrumented wasm
+pub const WASM_INSTR_VERSION_MAJOR : u32 = 0;
+pub const WASM_INSTR_VERSION_MINOR : u32 = 0; // TODO: bump this to match compiler when ready


### PR DESCRIPTION
Follows how it was done for Go.
For now observe-sdk tolerates the version information not being present.