### PR TITLE
feat: Add ability to set adapter scoped metadata

### DIFF
--- a/go/adapter.go
+++ b/go/adapter.go
@@ -21,6 +21,7 @@ type Adapter interface {
 type TraceEvent struct {
 	Events      []Event
 	TelemetryId TelemetryId
+	AdapterMeta interface{}
 }
 
 // Shared implementation for all Adapters

--- a/go/adapter/datadog/adapter.go
+++ b/go/adapter/datadog/adapter.go
@@ -79,6 +79,9 @@ func (d *DatadogAdapter) HandleTraceEvent(te observe.TraceEvent) {
 
 		if meta, ok := te.AdapterMeta.(DatadogMetadata); ok {
 			topSpan := allSpans[0]
+			if topSpan.Meta == nil {
+				topSpan.Meta = make(map[string]string)
+			}
 			if meta.ResourceName != nil {
 				topSpan.Resource = *meta.ResourceName
 			}
@@ -87,6 +90,24 @@ func (d *DatadogAdapter) HandleTraceEvent(te observe.TraceEvent) {
 			}
 			if meta.HttpStatusCode != nil {
 				topSpan.Meta["http.status_code"] = fmt.Sprintf("%d", *meta.HttpStatusCode)
+			}
+			if meta.HttpClientIp != nil {
+				topSpan.Meta["http.client_ip"] = *meta.HttpClientIp
+			}
+			if meta.HttpRequestContentLength != nil {
+				topSpan.Meta["http.request.content_length"] = fmt.Sprintf("%d", *meta.HttpRequestContentLength)
+			}
+			if meta.HttpRequestContentLengthUncompressed != nil {
+				topSpan.Meta["http.request.content_length_uncompressed"] = fmt.Sprintf("%d", *meta.HttpRequestContentLengthUncompressed)
+			}
+			if meta.HttpResponseContentLength != nil {
+				topSpan.Meta["http.response.content_length"] = fmt.Sprintf("%d", *meta.HttpResponseContentLength)
+			}
+			if meta.HttpResponseContentLengthUncompressed != nil {
+				topSpan.Meta["http.response.content_length_uncompressed"] = fmt.Sprintf("%d", *meta.HttpResponseContentLengthUncompressed)
+			}
+			if meta.SpanKind != nil {
+				topSpan.Meta["span.kind"] = meta.SpanKind.String()
 			}
 		}
 
@@ -139,10 +160,16 @@ func (d *DatadogAdapter) makeCallSpans(event observe.CallEvent, parentId *uint64
 }
 
 type DatadogMetadata struct {
-	HttpUrl        *string
-	HttpMethod     *string
-	HttpStatusCode *int
-	ResourceName   *string
+	HttpUrl                               *string
+	HttpMethod                            *string
+	HttpStatusCode                        *int
+	ResourceName                          *string
+	HttpClientIp                          *string
+	HttpRequestContentLength              *int
+	HttpRequestContentLengthUncompressed  *int
+	HttpResponseContentLength             *int
+	HttpResponseContentLengthUncompressed *int
+	SpanKind                              *DatadogSpanKind
 }
 
 type DatadogSpanKind int

--- a/go/adapter/datadog/adapter.go
+++ b/go/adapter/datadog/adapter.go
@@ -77,37 +77,41 @@ func (d *DatadogAdapter) HandleTraceEvent(te observe.TraceEvent) {
 	go func() {
 		output := datadog_formatter.New()
 
-		if meta, ok := te.AdapterMeta.(DatadogMetadata); ok {
-			topSpan := allSpans[0]
-			if topSpan.Meta == nil {
-				topSpan.Meta = make(map[string]string)
-			}
-			if meta.ResourceName != nil {
-				topSpan.Resource = *meta.ResourceName
-			}
-			if meta.HttpUrl != nil {
-				topSpan.Meta["http.url"] = *meta.HttpUrl
-			}
-			if meta.HttpStatusCode != nil {
-				topSpan.Meta["http.status_code"] = fmt.Sprintf("%d", *meta.HttpStatusCode)
-			}
-			if meta.HttpClientIp != nil {
-				topSpan.Meta["http.client_ip"] = *meta.HttpClientIp
-			}
-			if meta.HttpRequestContentLength != nil {
-				topSpan.Meta["http.request.content_length"] = fmt.Sprintf("%d", *meta.HttpRequestContentLength)
-			}
-			if meta.HttpRequestContentLengthUncompressed != nil {
-				topSpan.Meta["http.request.content_length_uncompressed"] = fmt.Sprintf("%d", *meta.HttpRequestContentLengthUncompressed)
-			}
-			if meta.HttpResponseContentLength != nil {
-				topSpan.Meta["http.response.content_length"] = fmt.Sprintf("%d", *meta.HttpResponseContentLength)
-			}
-			if meta.HttpResponseContentLengthUncompressed != nil {
-				topSpan.Meta["http.response.content_length_uncompressed"] = fmt.Sprintf("%d", *meta.HttpResponseContentLengthUncompressed)
-			}
-			if meta.SpanKind != nil {
-				topSpan.Meta["span.kind"] = meta.SpanKind.String()
+		if te.AdapterMeta != nil {
+			if meta, ok := te.AdapterMeta.(DatadogMetadata); ok {
+				topSpan := allSpans[0]
+				if topSpan.Meta == nil {
+					topSpan.Meta = make(map[string]string)
+				}
+				if meta.ResourceName != nil {
+					topSpan.Resource = *meta.ResourceName
+				}
+				if meta.HttpUrl != nil {
+					topSpan.Meta["http.url"] = *meta.HttpUrl
+				}
+				if meta.HttpStatusCode != nil {
+					topSpan.Meta["http.status_code"] = fmt.Sprintf("%d", *meta.HttpStatusCode)
+				}
+				if meta.HttpClientIp != nil {
+					topSpan.Meta["http.client_ip"] = *meta.HttpClientIp
+				}
+				if meta.HttpRequestContentLength != nil {
+					topSpan.Meta["http.request.content_length"] = fmt.Sprintf("%d", *meta.HttpRequestContentLength)
+				}
+				if meta.HttpRequestContentLengthUncompressed != nil {
+					topSpan.Meta["http.request.content_length_uncompressed"] = fmt.Sprintf("%d", *meta.HttpRequestContentLengthUncompressed)
+				}
+				if meta.HttpResponseContentLength != nil {
+					topSpan.Meta["http.response.content_length"] = fmt.Sprintf("%d", *meta.HttpResponseContentLength)
+				}
+				if meta.HttpResponseContentLengthUncompressed != nil {
+					topSpan.Meta["http.response.content_length_uncompressed"] = fmt.Sprintf("%d", *meta.HttpResponseContentLengthUncompressed)
+				}
+				if meta.SpanKind != nil {
+					topSpan.Meta["span.kind"] = meta.SpanKind.String()
+				}
+			} else {
+				log.Println("The Datadog adapter was expecting a DatadogMetadata object on the trace")
 			}
 		}
 

--- a/go/adapter/datadog_formatter/format.go
+++ b/go/adapter/datadog_formatter/format.go
@@ -37,7 +37,6 @@ func NewSpan(service string, traceId uint64, parentId *uint64, name string, star
 		Duration: uint64(end.Sub(start).Nanoseconds()),
 		Service:  service,
 		Resource: name,
-		Meta:     make(map[string]string),
 	}
 	return &span
 }

--- a/go/adapter/datadog_formatter/format.go
+++ b/go/adapter/datadog_formatter/format.go
@@ -37,6 +37,7 @@ func NewSpan(service string, traceId uint64, parentId *uint64, name string, star
 		Duration: uint64(end.Sub(start).Nanoseconds()),
 		Service:  service,
 		Resource: name,
+		Meta:     make(map[string]string),
 	}
 	return &span
 }

--- a/go/bin/datadog/main.go
+++ b/go/bin/datadog/main.go
@@ -46,6 +46,20 @@ func main() {
 	}
 	defer m.Close(ctx)
 
+	// normally this metadata would be in your web-server framework
+	// or derived when you need them. we're just gonna initialize
+	// some example values here
+	resourceName := "my-resource"
+	httpUrl := "https://example.com/my-endpoint"
+	httpStatusCode := 200
+
+	meta := datadog.DatadogMetadata{
+		ResourceName:   &resourceName,
+		HttpUrl:        &httpUrl,
+		HttpStatusCode: &httpStatusCode,
+	}
+	traceCtx.Metadata(meta)
+
 	traceCtx.Finish()
 
 	time.Sleep(time.Second * 2)

--- a/go/bin/datadog/main.go
+++ b/go/bin/datadog/main.go
@@ -52,11 +52,15 @@ func main() {
 	resourceName := "my-resource"
 	httpUrl := "https://example.com/my-endpoint"
 	httpStatusCode := 200
+	spanKind := datadog.Server
+	clientIp := "66.210.227.34"
 
 	meta := datadog.DatadogMetadata{
 		ResourceName:   &resourceName,
 		HttpUrl:        &httpUrl,
 		HttpStatusCode: &httpStatusCode,
+		SpanKind:       &spanKind,
+		HttpClientIp:   &clientIp,
 	}
 	traceCtx.Metadata(meta)
 

--- a/go/trace_ctx.go
+++ b/go/trace_ctx.go
@@ -34,6 +34,7 @@ type TraceCtx struct {
 	Config      *Config
 	names       map[uint32]string
 	telemetryId TelemetryId
+	adapterMeta interface{}
 }
 
 // Creates a new TraceCtx. Used internally by the Adapter. The user should create the trace context from the Adapter.
@@ -59,12 +60,17 @@ func newTraceCtx(ctx context.Context, adapter *AdapterBase, r wazero.Runtime, da
 	return traceCtx, nil
 }
 
+func (t *TraceCtx) Metadata(metadata interface{}) {
+	t.adapterMeta = metadata
+}
+
 // Finish() will stop the trace and send the
 // TraceEvent payload to the adapter
 func (t *TraceCtx) Finish() {
 	traceEvent := TraceEvent{
 		Events:      t.events,
 		TelemetryId: t.telemetryId,
+		AdapterMeta: t.adapterMeta,
 	}
 	t.adapter <- traceEvent
 	// clear the trace context


### PR DESCRIPTION
Partially addresses #40

We need a generic way to set the adapter specific metadata like we do in Rust. 