### PR TITLE
fix: memory allocation events should only be sent attached to function calls

### DIFF
--- a/rust/src/adapter/zipkin.rs
+++ b/rust/src/adapter/zipkin.rs
@@ -67,7 +67,7 @@ impl ZipkinAdapter {
         let mut ztf = ZipkinFormatter::new();
         ztf.spans = spans;
 
-        let mut first_span = ztf
+        let first_span = ztf
             .spans
             .first_mut()
             .context("No spans to send to zipkin")?;

--- a/rust/src/context.rs
+++ b/rust/src/context.rs
@@ -104,9 +104,6 @@ impl InstrumentationContext {
             self.stack.push(f);
         }
 
-        if let Err(e) = self.collector.try_send(ev) {
-            error!("error recording memory allocation: {}", e);
-        }
         Ok(())
     }
 }

--- a/rust/tests/many_tests.rs
+++ b/rust/tests/many_tests.rs
@@ -1,12 +1,9 @@
 #[cfg(test)]
 mod tests {
     use anyhow::Result;
-    use serde_json::Value;
-    use std::convert::identity;
     use std::process::Command;
 
     mod helpers;
-    use helpers::otel_json::*;
 
     #[test]
     fn integration_many() -> Result<()> {
@@ -26,21 +23,6 @@ mod tests {
         // First test that the modules ran the expected number of times
         assert_eq!(hellos, 250);
 
-        // check that every allocation was called
-        let traces = output_lines
-            .map(|l| match serde_json::from_str(l) {
-                Ok(x) => Some(x),
-                Err(_) => None,
-            })
-            .collect::<Vec<Option<Value>>>()
-            .into_iter()
-            .filter_map(identity)
-            .collect::<Vec<Value>>();
-        let allocations = traces
-            .iter()
-            .filter(|t| attribute_of_first_span(t, "name".to_string()).unwrap() == "allocation")
-            .count();
-        assert_eq!(allocations > 10, true);
         Ok(())
     }
 }

--- a/rust/tests/otel_json_tests.rs
+++ b/rust/tests/otel_json_tests.rs
@@ -7,7 +7,6 @@ mod tests {
     use serde_json::Value;
 
     mod helpers;
-    use helpers::otel_json::*;
 
     #[test]
     fn otel_stdout() -> Result<()> {
@@ -26,7 +25,7 @@ mod tests {
         let output = String::from_utf8(output.stdout)?;
 
         // traces is the collection of all traces emitted from this run
-        let traces = output
+        let _traces = output
             .lines()
             .map(|l| match serde_json::from_str(l) {
                 Ok(x) => Some(x),


### PR DESCRIPTION
I think the allocation should only ever be recorded as part of a function call event, not standlone. In the case prior to this commit, we actually collect the allocation as part of the function call (e.g. `sbrk`) and _also_ on its own, sent the allocation event along.