### PR TITLE
chore: demo readme update

### DIFF
--- a/demo-iota/README.md
+++ b/demo-iota/README.md
@@ -6,7 +6,7 @@ Iota maps the HTTP body to the Wasm function's standard input. And it maps the W
 
 There are only two endpoints:
 
-## `POST /upload?name=<module-name>`
+## `POST /upload?name=<identifier>`
 
 Post a Wasm module to this endpoint with any name you want.
 
@@ -14,7 +14,7 @@ Post a Wasm module to this endpoint with any name you want.
 curl -F wasm=@count_vowels.wasm  "https://p01--iota-web--tyqfmnr79gjf.code.run/upload?name=count_vowels" -X POST
 ```
 
-## `POST /run?name=<module-name>`
+## `POST /run?name=<identifier>`
 
 Post to this endpoint to run a function by name. The HTTP body will get passed to the function input. The function output will be returned in the HTTP response body
 

--- a/demo-iota/README.md
+++ b/demo-iota/README.md
@@ -8,7 +8,7 @@ There are only two endpoints:
 
 ## `POST /upload?name=<identifier>`
 
-Post a Wasm module to this endpoint with any name you want.
+Post a Wasm module to this endpoint using any name you want as the identifier:
 
 ```bash
 curl -F wasm=@count_vowels.wasm  "https://p01--iota-web--tyqfmnr79gjf.code.run/upload?name=count_vowels" -X POST

--- a/demo-iota/README.md
+++ b/demo-iota/README.md
@@ -6,7 +6,7 @@ Iota maps the HTTP body to the Wasm function's standard input. And it maps the W
 
 There are only two endpoints:
 
-## `POST /upload?name=<my-function-name>`
+## `POST /upload?name=<module-name>`
 
 Post a Wasm module to this endpoint with any name you want.
 
@@ -14,7 +14,7 @@ Post a Wasm module to this endpoint with any name you want.
 curl -F wasm=@count_vowels.wasm  "https://p01--iota-web--tyqfmnr79gjf.code.run/upload?name=count_vowels" -X POST
 ```
 
-## `POST /run?name=<my-function-name>`
+## `POST /run?name=<module-name>`
 
 Post to this endpoint to run a function by name. The HTTP body will get passed to the function input. The function output will be returned in the HTTP response body
 


### PR DESCRIPTION
@bhelx - just to confirm, I think we mean the name of the wasm module stored to disk? Since these are only WASI Command modules, its always calling `_start`, right? 

only clarifying here so that in the future if we do support calling an export function name, then there's no confusion. 