### PR TITLE
feat(iota): Pass response as raw bytes

### DIFF
--- a/demo-iota/go/main.go
+++ b/demo-iota/go/main.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"bytes"
-	"encoding/json"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -10,7 +9,6 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
-	"strings"
 
 	"github.com/dylibso/observe-sdk/go"
 	"github.com/dylibso/observe-sdk/go/adapter/datadog"
@@ -148,14 +146,7 @@ func (s *server) runModule(res http.ResponseWriter, req *http.Request) {
 	log.Println("stopped collector, sent to datadog")
 	defer mod.Close(ctx)
 
-	data, err := json.Marshal(Output{Stdout: strings.Trim(output.String(), "\n")})
-	if err != nil {
-		log.Println("json encode error:", err)
-		res.WriteHeader(http.StatusInternalServerError)
-		res.Write([]byte("Internal Service Error"))
-		return
-	}
 	res.WriteHeader(http.StatusOK)
 	res.Header().Add("content-type", "application/json")
-	res.Write(data)
+	res.Write(output.Bytes())
 }

--- a/demo-iota/rust/Cargo.lock
+++ b/demo-iota/rust/Cargo.lock
@@ -866,7 +866,6 @@ dependencies = [
  "dylibso-observe-sdk",
  "futures-util",
  "serde",
- "serde_json",
  "tokio",
  "wasi-common",
  "wasmtime",

--- a/demo-iota/rust/Cargo.toml
+++ b/demo-iota/rust/Cargo.toml
@@ -11,7 +11,6 @@ edition = "2021"
 anyhow = "1.0.71"
 axum = { version = "0.6.18", features = ["multipart"] }
 serde = "1.0.164"
-serde_json = "1.0.96"
 tokio = { version = "1.28.2", features = ["macros", "rt-multi-thread"] }
 wasi-common = "8.0.0"
 wasmtime = "8.0.0"


### PR DESCRIPTION
I think it makes a bit more sense to just return the raw bytes from the module response to the http response body rather than assuming we want json. this opens us up to different content types like html, images, etc.