### PR TITLE
fix: js name parsing - reading subsection ids >= 128 and error handling

### DIFF
--- a/js/src/lib/parser/mod.ts
+++ b/js/src/lib/parser/mod.ts
@@ -4,37 +4,45 @@ export function parseNameSection(nameSection: ArrayBuffer): Map<number, string> 
     const nameSectionView = new DataView(nameSection);
     const fnNameMap = new Map<number, string>;
     let offset = 0;
+    try {
+        while (offset < nameSection.byteLength) {
+            const subsectionId = readByte(nameSectionView, offset);
+            offset += subsectionId.bytesRead;
 
-    while (offset < nameSection.byteLength) {
-        const subsectionId = readLEB128(nameSectionView, offset);
-        offset += subsectionId.bytesRead;
+            const subsectionLength = readLEB128(nameSectionView, offset);
+            offset += subsectionLength.bytesRead;
+            const subsectionEnd = offset + subsectionLength.value;
 
-        const subsectionLength = readLEB128(nameSectionView, offset);
-        offset += subsectionLength.bytesRead;
-        const subsectionEnd = offset + subsectionLength.value;
+            // function name subsection is subsection id 1
+            if (subsectionId.value === 0x01) {
+                const nameMapLength = readLEB128(nameSectionView, offset);
+                offset += nameMapLength.bytesRead;
 
-        // function name subsection is subsection id 1
-        if (subsectionId.value === 0x01) {
-            const nameMapLength = readLEB128(nameSectionView, offset);
-            offset += nameMapLength.bytesRead;
+                // process namemap
+                for (let nameMapCount = 0; nameMapCount < nameMapLength.value; nameMapCount++) {
+                    const nameIdx = readLEB128(nameSectionView, offset);
+                    offset += nameIdx.bytesRead;
 
-            // process namemap
-            while (offset < subsectionEnd) {
-                const nameIdx = readLEB128(nameSectionView, offset);
-                offset += nameIdx.bytesRead;
+                    const nameLength = readLEB128(nameSectionView, offset);
+                    offset += nameLength.bytesRead;
 
-                const nameLength = readLEB128(nameSectionView, offset);
-                offset += nameLength.bytesRead;
+                    const fnName = new TextDecoder().decode(nameSection.slice(offset, offset + nameLength.value));
+                    offset += nameLength.value;
 
-                const fnName = new TextDecoder().decode(nameSection.slice(offset, offset + nameLength.value));
-                offset += nameLength.value;
-
-                fnNameMap.set(nameIdx.value, fnName);
+                    fnNameMap.set(nameIdx.value, fnName);
+                }
+                if (offset < subsectionEnd) {
+                    console.warn("suspicious: at end of name map, but not its name subsection");
+                    offset = subsectionEnd;
+                }
+            } else {
+                // skip this subsection
+                offset = subsectionEnd;
             }
-        } else {
-            // skip this subsection
-            offset = subsectionEnd;
         }
+    } catch (error) {
+        // WASM probably has a corrupt name section, log the error and return what we got
+        console.error(error);
     }
     return fnNameMap;
 }
@@ -52,4 +60,9 @@ function readLEB128(view: DataView, offset: number): { value: number, bytesRead:
         bytesRead++;
     } while (byte & 0x80);
     return { value: result, bytesRead };
+}
+
+function readByte(view: DataView, offset: number): { value: number, bytesRead: number } {
+    const byte = view.getUint8(offset);
+    return { value: byte, bytesRead: 1 };
 }


### PR DESCRIPTION
Wrapping most of it with a try catch created an unfortunate diff.

This improves the reliability and accuracy of the name parsing:

1. Reads the name subsection id as a byte so ids `>= 128` are supported.
2. Wraps `nameSectionView` accesses with `try...catch` so out of bound accesses  (`RangeError`) will just cease parsing of name section and return the names with successfully parsed before that point.
3. Only reads up to `nameMapLength.value` names from a subsection instead of relying it the namemap going until the end of the subsection. If there's leftover bytes in a subsection, they are skipped, and a warning is logged. 