### PR TITLE
fix: install protoc in rust iota dockerfile

### DIFF
--- a/demo-iota/rust/Dockerfile
+++ b/demo-iota/rust/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu
 
-RUN apt update -y && apt install libssl-dev pkg-config openssl curl build-essential -y
+RUN apt update -y && apt install libssl-dev pkg-config openssl curl build-essential protobuf-compiler -y
 
 RUN curl https://sh.rustup.rs -sSf | bash -s -- -y
 ENV PATH="/root/.cargo/bin:${PATH}"


### PR DESCRIPTION
Should fix the rust iota builds/deployments by installing protoc in the Dockerfile