### PR TITLE
fix: parse modules with no compat versions

### DIFF
--- a/go/wasm.go
+++ b/go/wasm.go
@@ -13,6 +13,8 @@ import (
 const wasmInstrVersionMajor = 0
 const wasmInstrVersionMinor = 0 // TODO: bump this to match compiler when ready
 
+var errorNoCompatibilityVersion = errors.New("No compatibility versions in module")
+
 // make sure that our function was instrumented with a compatible
 // version of wasm-instr
 func checkVersion(m *wasm.Module) error {
@@ -31,7 +33,7 @@ func checkVersion(m *wasm.Module) error {
 	}
 
 	if minorGlobal == nil || majorGlobal == nil {
-		return errors.New("wasm_instr_version functions not found")
+		return errorNoCompatibilityVersion
 	}
 
 	minor, _, err := leb128.DecodeUint32(bytes.NewReader(m.GlobalSection[minorGlobal.Index].Init.Data))
@@ -60,7 +62,7 @@ func parseNames(data []byte) (map[uint32]string, error) {
 	}
 
 	// Check for version globals
-	if err := checkVersion(m); err != nil {
+	if err := checkVersion(m); err != nil && err != errorNoCompatibilityVersion {
 		return nil, err
 	}
 

--- a/rust/src/adapter/otelstdout.rs
+++ b/rust/src/adapter/otelstdout.rs
@@ -18,8 +18,10 @@ impl Adapter for OtelStdoutAdapter {
         for span in trace_evt.events {
             self.event_to_spans(&mut spans, span, vec![], trace_id.clone())?;
         }
-        let otf = OtelFormatter::new(spans, "stdout".into());
-        println!("{:?}", &otf.traces_data);
+        if !spans.is_empty() {
+            let otf = OtelFormatter::new(spans, "stdout".into());
+            println!("{:?}", &otf.traces_data);
+        }
         Ok(())
     }
 }

--- a/rust/src/wasm_instr.rs
+++ b/rust/src/wasm_instr.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use anyhow::{bail, Context, Result};
+use anyhow::{bail, Result};
 
 // these control the versions of instrumented wasm supported
 // WASM_INSTR_VERSION_MAJOR must match the instrumented wasm
@@ -17,12 +17,12 @@ pub struct WasmInstrInfo {
 
 impl WasmInstrInfo {
     pub fn check_version(&self) -> Result<()> {
-        let maj_num = self
-            .maj_version
-            .context("wasm-instr missing major version")?;
-        let min_num = self
-            .min_version
-            .context("wasm-instr missing minor version")?;
+        if self.maj_version.is_none() && self.min_version.is_none() {
+            // likely this is an uninstrumented module, or not instrumented with automation
+            return Ok(());
+        }
+        let maj_num = self.maj_version.unwrap();
+        let min_num = self.min_version.unwrap();
 
         if maj_num != WASM_INSTR_VERSION_MAJOR {
             bail!("wasm wasm-instr major version {maj_num} is not equal to {WASM_INSTR_VERSION_MAJOR}!")


### PR DESCRIPTION
Fixes issue when modules without any version compatibility information from the compiler are parsed.

Additionally only prints trace output in the Rust `otel-stdout` example if there are any spans to format.