### PR TITLE
fix(rust): memory allocation in filtered spans

### DIFF
--- a/rust/examples/honeycomb.rs
+++ b/rust/examples/honeycomb.rs
@@ -33,7 +33,7 @@ pub async fn main() -> anyhow::Result<()> {
 
     let options = Options {
         span_filter: SpanFilter {
-            min_duration_microseconds: std::time::Duration::from_micros(20),
+            min_duration_microseconds: std::time::Duration::from_micros(2000),
         },
     };
     // Provide the observability functions to the `Linker` to be made available

--- a/rust/examples/honeycomb.rs
+++ b/rust/examples/honeycomb.rs
@@ -33,7 +33,7 @@ pub async fn main() -> anyhow::Result<()> {
 
     let options = Options {
         span_filter: SpanFilter {
-            min_duration_microseconds: std::time::Duration::from_micros(2000),
+            min_duration_microseconds: std::time::Duration::from_micros(20),
         },
     };
     // Provide the observability functions to the `Linker` to be made available

--- a/rust/src/adapter/datadog.rs
+++ b/rust/src/adapter/datadog.rs
@@ -198,7 +198,6 @@ impl DatadogAdapter {
                 }
             }
             Event::Alloc(a) => {
-                // TODO i seem to be losing this value
                 if let Some(span) = ddevents.spans.last_mut() {
                     span.add_allocation(a.amount);
                 }

--- a/rust/src/adapter/datadog_formatter/mod.rs
+++ b/rust/src/adapter/datadog_formatter/mod.rs
@@ -69,14 +69,13 @@ impl Span {
 
     pub fn add_allocation(&mut self, amount: u32) {
         let key = "allocation".to_string();
+        let mut amount = amount;
         if let Some(alloc) = self.meta.get(key.as_str()) {
             if let Ok(v) = alloc.parse::<u32>() {
-                let sum_amount = v + amount;
-                self.meta.insert(key, sum_amount.to_string());
+                amount = v + amount;
             }
-        } else {
-            self.meta.insert(key, amount.to_string());
         }
+        self.meta.insert(key, amount.to_string());
     }
 
     pub fn add_tag(&mut self, tag: String) {

--- a/rust/src/adapter/datadog_formatter/mod.rs
+++ b/rust/src/adapter/datadog_formatter/mod.rs
@@ -68,8 +68,15 @@ impl Span {
     }
 
     pub fn add_allocation(&mut self, amount: u32) {
-        self.meta
-            .insert("allocation".to_string(), amount.to_string());
+        let key = "allocation".to_string();
+        if let Some(alloc) = self.meta.get(key.as_str()) {
+            if let Ok(v) = alloc.parse::<u32>() {
+                let sum_amount = v + amount;
+                self.meta.insert(key, sum_amount.to_string());
+            }
+        } else {
+            self.meta.insert(key, amount.to_string());
+        }
     }
 
     pub fn add_tag(&mut self, tag: String) {

--- a/rust/src/adapter/lightstep.rs
+++ b/rust/src/adapter/lightstep.rs
@@ -1,13 +1,10 @@
 use prost::Message;
 use std::time::Duration;
 
-use crate::{Event, TraceEvent};
+use crate::TraceEvent;
 use anyhow::Result;
 
-use super::{
-    otel_formatter::{opentelemetry, OtelFormatter},
-    Adapter, AdapterHandle,
-};
+use super::{otel_formatter::OtelFormatter, Adapter, AdapterHandle};
 
 pub use super::{
     otel_formatter::{Attribute, Value},
@@ -47,72 +44,12 @@ impl LightstepAdapter {
         })
     }
 
-    fn event_to_spans(
-        &self,
-        spans: &mut Vec<opentelemetry::proto::trace::v1::Span>,
-        event: Event,
-        parent_id: Vec<u8>,
-        trace_id: String,
-        meta: &Option<AdapterMetadata>,
-    ) -> Result<()> {
-        match event {
-            Event::Func(f) => {
-                let name = f.name.clone().unwrap_or("unknown-name".to_string());
-
-                let mut span =
-                    OtelFormatter::new_span(trace_id.clone(), parent_id, name, f.start, f.end);
-                let span_id = span.span_id.clone();
-                if let Some(m) = meta {
-                    if let AdapterMetadata::OpenTelemetry(m) = m {
-                        for entry in m.iter() {
-                            if let Some(v) = entry.value.int_value {
-                                OtelFormatter::add_attribute_i64_to_span(
-                                    &mut span,
-                                    entry.key.clone(),
-                                    v,
-                                )
-                            } else if let Some(v) = entry.value.string_value.clone() {
-                                OtelFormatter::add_attribute_string_to_span(
-                                    &mut span,
-                                    entry.key.clone(),
-                                    v,
-                                )
-                            }
-                        }
-                    }
-                }
-                spans.push(span);
-
-                for e in f.within.iter() {
-                    self.event_to_spans(
-                        spans,
-                        e.to_owned(),
-                        span_id.clone(),
-                        trace_id.clone(),
-                        &meta,
-                    )?;
-                }
-            }
-            Event::Alloc(a) => {
-                if let Some(span) = spans.last_mut() {
-                    OtelFormatter::add_attribute_i64_to_span(
-                        span,
-                        "allocation".to_string(),
-                        a.amount.into(),
-                    );
-                }
-            }
-            _ => {}
-        }
-        Ok(())
-    }
-
     fn dump_traces(&mut self) -> Result<()> {
         let mut spans = vec![];
         for te in &self.trace_events {
             let trace_id = te.telemetry_id.to_hex_16();
             for span in &te.events {
-                self.event_to_spans(
+                self.event_to_otel_spans(
                     &mut spans,
                     span.clone(),
                     vec![],

--- a/rust/src/adapter/otelstdout.rs
+++ b/rust/src/adapter/otelstdout.rs
@@ -1,6 +1,6 @@
 use std::vec;
 
-use crate::{adapter::otel_formatter::opentelemetry::proto::trace, Event, TraceEvent};
+use crate::{Event, TraceEvent};
 use anyhow::Result;
 
 use super::{

--- a/rust/src/adapter/zipkin.rs
+++ b/rust/src/adapter/zipkin.rs
@@ -55,7 +55,14 @@ impl ZipkinAdapter {
             }
             Event::Alloc(a) => {
                 if let Some(span) = spans.last_mut() {
-                    span.add_tag_i64("amount".to_string(), a.amount.into());
+                    let key = "amount".to_string();
+                    let mut amount = a.amount;
+                    if let Some(alloc) = span.tags.get(key.as_str()) {
+                        if let Ok(v) = alloc.parse::<u32>() {
+                            amount = v + a.amount;
+                        }
+                    }
+                    span.add_tag_i64(key, amount.into());
                 }
             }
             _ => {}

--- a/rust/src/context.rs
+++ b/rust/src/context.rs
@@ -97,6 +97,16 @@ impl InstrumentationContext {
                     .min_duration_microseconds
                     .as_micros();
                 if func_duration < min_span_duration {
+                    // check for memory allocations and attribute them to the parent span
+                    if let Some(mut f) = self.stack.pop() {
+                        func.within.into_iter().for_each(|ev| match ev {
+                            Event::Alloc(e) => {
+                                f.within.push(Event::Alloc(e));
+                            }
+                            _ => {}
+                        });
+                        self.stack.push(f);
+                    }
                     return Ok(());
                 }
 


### PR DESCRIPTION
- Give base Adapter trait the ability to construct OTEL call spans (since this is industry standard and most common format)
- Hoist (and sum) memory allocations to parent span when current span is being filtered

