### PR TITLE
fix(js): memory allocation in filtered spans

### DIFF
--- a/js/src/lib/adapters/datadog/formatter.ts
+++ b/js/src/lib/adapters/datadog/formatter.ts
@@ -46,7 +46,7 @@ export const addAllocation = (span: Span, amount: MemoryGrowAmount) => {
     try {
       sumAmount = parseInt(existingAllocation) + amount;
     } catch (e) {
-      console.error(e)
+      console.error(e);
     }
   }
   span.meta.set(allocationKey, sumAmount.toString());

--- a/js/src/lib/adapters/datadog/formatter.ts
+++ b/js/src/lib/adapters/datadog/formatter.ts
@@ -37,8 +37,19 @@ export class Trace {
   }
 }
 
+const allocationKey = 'allocation';
+
 export const addAllocation = (span: Span, amount: MemoryGrowAmount) => {
-  span.meta.set("allocation", amount.toString());
+  let sumAmount = amount;
+  let existingAllocation = span.meta[allocationKey];
+  if (existingAllocation) {
+    try {
+      sumAmount = parseInt(existingAllocation) + amount;
+    } catch (e) {
+      console.error(e)
+    }
+  }
+  span.meta.set(allocationKey, sumAmount.toString());
 };
 
 export class DatadogFormatter {

--- a/js/src/lib/formatters/opentelemetry.ts
+++ b/js/src/lib/formatters/opentelemetry.ts
@@ -53,17 +53,30 @@ function eventToSpans(trace: Trace, spans: Span[], ev: ObserveEvent, parentId?: 
 
         ev.within.forEach((e) => {
             eventToSpans(trace, spans, e, span.spanId);
-        })
+        });
     }
     else if (ev instanceof MemoryGrow) {
-        const span = newSpan(trace, 'allocation', ev.start, ev.start, parentId);
-        span.attributes.push({
-            key: 'amount',
-            value: {
-                intValue: ev.amount,
-            }
-        })
-        spans.push(span);
+        const span = spans[spans.length - 1];
+        let existingIndex = -1;
+        const existing = span.attributes.find((a, i) => {
+            existingIndex = i;
+            return a.key === 'amount'
+        });
+        if (existing) {
+            span.attributes[existingIndex] = {
+                key: 'amount',
+                value: {
+                    intValue: ev.amount + existing.value.intValue
+                }
+            };
+        } else {
+            span.attributes.push({
+                key: 'amount',
+                value: {
+                    intValue: ev.amount,
+                }
+            });
+        }
     }
 }
 

--- a/js/src/lib/formatters/opentelemetry.ts
+++ b/js/src/lib/formatters/opentelemetry.ts
@@ -40,6 +40,7 @@ export function traceFromEvents(serviceName: string, events: ObserveEvent[]): Tr
     return trace;
 }
 
+const allocationKey = 'allocation';
 /**
  * 
  * @param trace - all spans created will be tied to this trace
@@ -60,18 +61,18 @@ function eventToSpans(trace: Trace, spans: Span[], ev: ObserveEvent, parentId?: 
         let existingIndex = -1;
         const existing = span.attributes.find((a, i) => {
             existingIndex = i;
-            return a.key === 'amount'
+            return a.key === allocationKey
         });
         if (existing) {
             span.attributes[existingIndex] = {
-                key: 'amount',
+                key: allocationKey,
                 value: {
                     intValue: ev.amount + existing.value.intValue
                 }
             };
         } else {
             span.attributes.push({
-                key: 'amount',
+                key: allocationKey,
                 value: {
                     intValue: ev.amount,
                 }


### PR DESCRIPTION
- Hoist (and sum) memory allocations to parent span when current span is being filtered
- fix bug in which allocations created their own spans for otel based adapters