### PR TITLE
chore: impl default on options, update calls

### DIFF
--- a/rust/examples/basic.rs
+++ b/rust/examples/basic.rs
@@ -1,4 +1,4 @@
-use dylibso_observe_sdk::adapter::{default_options, stdout::StdoutAdapter};
+use dylibso_observe_sdk::adapter::stdout::StdoutAdapter;
 
 #[tokio::main]
 pub async fn main() -> anyhow::Result<()> {
@@ -27,7 +27,7 @@ pub async fn main() -> anyhow::Result<()> {
     // Provide the observability functions to the `Linker` to be made available
     // to the instrumented guest code. These are safe to add and are a no-op
     // if guest code is uninstrumented.
-    let trace_ctx = adapter.start(&mut linker, &data, default_options())?;
+    let trace_ctx = adapter.start(&mut linker, &data, Default::default())?;
 
     let instance = linker.instantiate(&mut store, &module)?;
 

--- a/rust/examples/many.rs
+++ b/rust/examples/many.rs
@@ -1,7 +1,4 @@
-use dylibso_observe_sdk::{
-    adapter::{default_options, otelstdout::OtelStdoutAdapter},
-    new_trace_id,
-};
+use dylibso_observe_sdk::{adapter::otelstdout::OtelStdoutAdapter, new_trace_id};
 use rand::{seq::SliceRandom, thread_rng};
 
 #[tokio::main]
@@ -36,7 +33,7 @@ pub async fn main() -> anyhow::Result<()> {
             // Provide the observability functions to the `Linker` to be made
             // available to the instrumented guest code. These are safe to add
             // and are a no-op if guest code is uninstrumented.
-            let trace_ctx = adapter.start(&mut linker, &data, default_options())?;
+            let trace_ctx = adapter.start(&mut linker, &data, Default::default())?;
 
             let instance = linker.instantiate(&mut store, &module)?;
             instances.push((trace_ctx, instance, store));

--- a/rust/examples/otel-stdout.rs
+++ b/rust/examples/otel-stdout.rs
@@ -1,4 +1,4 @@
-use dylibso_observe_sdk::adapter::{default_options, otelstdout::OtelStdoutAdapter};
+use dylibso_observe_sdk::adapter::otelstdout::OtelStdoutAdapter;
 
 #[tokio::main]
 pub async fn main() -> anyhow::Result<()> {
@@ -27,7 +27,7 @@ pub async fn main() -> anyhow::Result<()> {
     // Provide the observability functions to the `Linker` to be made available
     // to the instrumented guest code. These are safe to add and are a no-op
     // if guest code is uninstrumented.
-    let trace_ctx = adapter.start(&mut linker, &data, default_options())?;
+    let trace_ctx = adapter.start(&mut linker, &data, Default::default())?;
 
     let instance = linker.instantiate(&mut store, &module)?;
 

--- a/rust/examples/zipkin.rs
+++ b/rust/examples/zipkin.rs
@@ -1,4 +1,4 @@
-use dylibso_observe_sdk::adapter::{default_options, zipkin::ZipkinAdapter};
+use dylibso_observe_sdk::adapter::zipkin::ZipkinAdapter;
 
 #[tokio::main]
 pub async fn main() -> anyhow::Result<()> {
@@ -27,7 +27,7 @@ pub async fn main() -> anyhow::Result<()> {
     // Provide the observability functions to the `Linker` to be made available
     // to the instrumented guest code. These are safe to add and are a no-op
     // if guest code is uninstrumented.
-    let trace_ctx = adapter.start(&mut linker, &data, default_options())?;
+    let trace_ctx = adapter.start(&mut linker, &data, Default::default())?;
 
     let instance = linker.instantiate(&mut store, &module)?;
 

--- a/rust/src/adapter/mod.rs
+++ b/rust/src/adapter/mod.rs
@@ -196,10 +196,22 @@ pub enum AdapterMetadata {
     OpenTelemetry(Vec<Attribute>),
 }
 
+const MIN_SPAN_FILTER_DURATION_DEFAULT: u64 = 20;
+
 /// SpanFilter allows for specification of how to filter out spans
 #[derive(Clone)]
 pub struct SpanFilter {
     pub min_duration_microseconds: std::time::Duration,
+}
+
+impl Default for SpanFilter {
+    fn default() -> Self {
+        Self {
+            min_duration_microseconds: std::time::Duration::from_micros(
+                MIN_SPAN_FILTER_DURATION_DEFAULT,
+            ),
+        }
+    }
 }
 
 /// Options allow you to tune certain characteristics of your telemetry
@@ -208,11 +220,14 @@ pub struct Options {
     pub span_filter: SpanFilter,
 }
 
-/// default_options is a convenience method for setting sane default options
-pub fn default_options() -> Options {
-    Options {
-        span_filter: SpanFilter {
-            min_duration_microseconds: std::time::Duration::from_micros(20),
-        },
+impl Default for Options {
+    fn default() -> Self {
+        Self {
+            span_filter: SpanFilter {
+                min_duration_microseconds: std::time::Duration::from_micros(
+                    MIN_SPAN_FILTER_DURATION_DEFAULT,
+                ),
+            },
+        }
     }
 }

--- a/rust/src/adapter/otelstdout.rs
+++ b/rust/src/adapter/otelstdout.rs
@@ -1,12 +1,9 @@
 use std::vec;
 
-use crate::{Event, TraceEvent};
+use crate::TraceEvent;
 use anyhow::Result;
 
-use super::{
-    otel_formatter::{opentelemetry, OtelFormatter},
-    Adapter, AdapterHandle,
-};
+use super::{otel_formatter::OtelFormatter, Adapter, AdapterHandle};
 
 /// An adapter to send events from your module to stdout using OpenTelemetry json format.
 pub struct OtelStdoutAdapter {}


### PR DESCRIPTION
Just converting the `default_options` function to use rust's built-in concept for this, the `Default` trait. 

```patch
- ...start(_, _, default_options())?;
+ ...start(_, _, Default::default())?;
```

I'm still not 100% sure about the change to the `start` method though.. and after trying a couple things we might just want to wait and see what user feedback is. The main thing I'm kind of hung up on is whether or not to take an `Option<Options>` in `start` or keep it non-optional. 

The confusing this is what the actual intent is when `None` is passed to `start`... do we use a completely unfiltered trace (what else when there are more fields on `Options`?) , or should `None` indicate the "just use the defaults"? 

Many Rust programmers will see if `Option<T>` is the arg, `None` is a convenient way to say "use nothing", but I don't really know what "nothing" should be in this case. 