### PR TITLE
cleanup: avoid initializing dylibso_observe module multiple times

### DIFF
--- a/go/trace_ctx.go
+++ b/go/trace_ctx.go
@@ -79,6 +79,11 @@ func (t *TraceCtx) withListener(ctx context.Context) context.Context {
 // Should only be called once.
 func (t *TraceCtx) init(ctx context.Context, r wazero.Runtime) error {
 	ctx = t.withListener(ctx)
+
+	if r.Module("dylibso_observe") != nil {
+		return nil
+	}
+
 	observe := r.NewHostModuleBuilder("dylibso_observe")
 	functions := observe.NewFunctionBuilder()
 


### PR DESCRIPTION
Avoid adding the dylibso_observe functions multiple times, fixes an issue we're running into in: https://github.com/bacalhau-project/bacalhau/pull/2971