### PR TITLE
fix(ci): upgrade go version to 1.22

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,6 +56,8 @@ jobs:
 
       - name: Install Go toolchain
         uses: actions/setup-go@v4
+        with:
+          go-version: '1.22'
 
       - name: Run go test
         run: |


### PR DESCRIPTION
Fixes #173 

It seems like the latest version of wazero requires Go v1.22+